### PR TITLE
fix(deallocate_middle): advance to next in try_insert_after

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -435,6 +435,11 @@ impl Cursor {
 
             // If we have a next, does the node overlap next?
             if let Some(next) = self.current().next.as_ref() {
+                if next < &node {
+                    // advance the list more
+                    return Err(());
+                }
+
                 let node_u8 = node_u8 as *const u8;
                 assert!(
                     node_u8.wrapping_add(node_size) <= next.as_ptr().cast::<u8>(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -151,9 +151,10 @@ fn deallocate_middle() {
         heap.deallocate(z, layout.clone());
         assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
         assert_eq!((*(z.as_ptr() as *const Hole)).size, size);
-        heap.deallocate(y, layout.clone());
-        assert_eq!((*(x.as_ptr() as *const Hole)).size, size * 3);
         heap.deallocate(a, layout.clone());
+        assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
+        assert_eq!((*(z.as_ptr() as *const Hole)).size, heap.size - 2 * size);
+        heap.deallocate(y, layout.clone());
         assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size);
     }
 }


### PR DESCRIPTION
If the next hole node is still lower than the hole to be added, advance the cursor to the next in the list.

For this to trigger, this patch modifies the `deallocate_middle()` test.
It requires two holes in the list before the one to be deallocated.

Signed-off-by: Harald Hoyer <harald@profian.com>