### PR TITLE
Fix build on stable by adding missing field in `HoleList` initializer

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -266,6 +266,7 @@ impl HoleList {
             },
             bottom: null_mut(),
             top: null_mut(),
+            pending_extend: 0,
         }
     }
 


### PR DESCRIPTION
Fixes a minor bug that led to a build failure when compiling with `--no-default-features`, e.g. when using stable Rust. This issue was introduced in the just released `v0.10.2`.

We did not catch it earlier because we bypassed the CI for the `v0.10.2` release because it fixed a [security vulnerability](https://github.com/rust-osdev/linked-list-allocator/security/advisories/GHSA-xg8p-34w2-j49j).