### PR TITLE
Consider regions that lead to very small back paddings as unsuitable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     name: "Miri tests"
     runs-on: ubuntu-latest
     env:
-      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers -Zmiri-ignore-leaks"
+      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers"
     steps:
     - uses: actions/checkout@v1
     - run: rustup toolchain install nightly --profile minimal --component rust-src miri

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -697,34 +697,9 @@ fn deallocate(list: &mut HoleList, addr: *mut u8, size: usize) {
 #[cfg(test)]
 pub mod test {
     use super::HoleList;
-    use crate::{align_down_size, Heap};
+    use crate::{align_down_size, test::new_heap};
     use core::mem::size_of;
-    use std::{alloc::Layout, convert::TryInto, mem::MaybeUninit, prelude::v1::*, ptr::NonNull};
-
-    #[repr(align(128))]
-    struct Chonk<const N: usize> {
-        data: [MaybeUninit<u8>; N],
-    }
-
-    impl<const N: usize> Chonk<N> {
-        pub fn new() -> Self {
-            Self {
-                data: [MaybeUninit::uninit(); N],
-            }
-        }
-    }
-
-    fn new_heap() -> Heap {
-        const HEAP_SIZE: usize = 1000;
-        let heap_space = Box::leak(Box::new(Chonk::<HEAP_SIZE>::new()));
-        let data = &mut heap_space.data;
-        let assumed_location = data.as_mut_ptr().cast();
-
-        let heap = Heap::from_slice(data);
-        assert_eq!(heap.bottom(), assumed_location);
-        assert_eq!(heap.size(), align_down_size(HEAP_SIZE, size_of::<usize>()));
-        heap
-    }
+    use std::{alloc::Layout, convert::TryInto, prelude::v1::*, ptr::NonNull};
 
     #[test]
     fn cursor() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,8 +1,12 @@
 use super::*;
-use core::alloc::Layout;
-use core::ops::DerefMut;
-use std::mem::{align_of, size_of, MaybeUninit};
-use std::prelude::v1::*;
+use core::{
+    alloc::Layout,
+    ops::{Deref, DerefMut},
+};
+use std::{
+    mem::{align_of, size_of, MaybeUninit},
+    prelude::v1::*,
+};
 
 #[repr(align(128))]
 struct Chonk<const N: usize> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use core::alloc::Layout;
+use core::ops::DerefMut;
 use std::mem::{align_of, size_of, MaybeUninit};
 use std::prelude::v1::*;
 
@@ -16,22 +17,45 @@ impl<const N: usize> Chonk<N> {
     }
 }
 
-fn new_heap() -> Heap {
+pub struct OwnedHeap<F> {
+    heap: Heap,
+    _drop: F,
+}
+
+impl<F> Deref for OwnedHeap<F> {
+    type Target = Heap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.heap
+    }
+}
+
+impl<F> DerefMut for OwnedHeap<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.heap
+    }
+}
+
+pub fn new_heap() -> OwnedHeap<impl Sized> {
     const HEAP_SIZE: usize = 1000;
-    let heap_space = Box::leak(Box::new(Chonk::<HEAP_SIZE>::new()));
+    let mut heap_space = Box::new(Chonk::<HEAP_SIZE>::new());
     let data = &mut heap_space.data;
     let assumed_location = data.as_mut_ptr().cast();
 
-    let heap = Heap::from_slice(data);
+    let heap = unsafe { Heap::new(data.as_mut_ptr().cast(), data.len()) };
     assert_eq!(heap.bottom(), assumed_location);
     assert_eq!(heap.size(), align_down_size(HEAP_SIZE, size_of::<usize>()));
-    heap
+
+    let drop = move || {
+        let _ = heap_space;
+    };
+    OwnedHeap { heap, _drop: drop }
 }
 
-fn new_max_heap() -> Heap {
+fn new_max_heap() -> OwnedHeap<impl Sized> {
     const HEAP_SIZE: usize = 1024;
     const HEAP_SIZE_MAX: usize = 2048;
-    let heap_space = Box::leak(Box::new(Chonk::<HEAP_SIZE_MAX>::new()));
+    let mut heap_space = Box::new(Chonk::<HEAP_SIZE_MAX>::new());
     let data = &mut heap_space.data;
     let start_ptr = data.as_mut_ptr().cast();
 
@@ -39,7 +63,23 @@ fn new_max_heap() -> Heap {
     let heap = unsafe { Heap::new(start_ptr, HEAP_SIZE) };
     assert_eq!(heap.bottom(), start_ptr);
     assert_eq!(heap.size(), HEAP_SIZE);
-    heap
+
+    let drop = move || {
+        let _ = heap_space;
+    };
+    OwnedHeap { heap, _drop: drop }
+}
+
+fn new_heap_skip(ct: usize) -> OwnedHeap<impl Sized> {
+    const HEAP_SIZE: usize = 1000;
+    let mut heap_space = Box::new(Chonk::<HEAP_SIZE>::new());
+    let data = &mut heap_space.data[ct..];
+    let heap = unsafe { Heap::new(data.as_mut_ptr().cast(), data.len()) };
+
+    let drop = move || {
+        let _ = heap_space;
+    };
+    OwnedHeap { heap, _drop: drop }
 }
 
 #[test]
@@ -51,7 +91,15 @@ fn empty() {
 
 #[test]
 fn oom() {
-    let mut heap = new_heap();
+    const HEAP_SIZE: usize = 1000;
+    let mut heap_space = Box::new(Chonk::<HEAP_SIZE>::new());
+    let data = &mut heap_space.data;
+    let assumed_location = data.as_mut_ptr().cast();
+
+    let mut heap = unsafe { Heap::new(data.as_mut_ptr().cast(), data.len()) };
+    assert_eq!(heap.bottom(), assumed_location);
+    assert_eq!(heap.size(), align_down_size(HEAP_SIZE, size_of::<usize>()));
+
     let layout = Layout::from_size_align(heap.size() + 1, align_of::<usize>());
     let addr = heap.allocate_first_fit(layout.unwrap());
     assert!(addr.is_err());
@@ -386,14 +434,6 @@ fn allocate_multiple_unaligned() {
             heap.deallocate(b, layout_1);
         }
     }
-}
-
-fn new_heap_skip(ct: usize) -> Heap {
-    const HEAP_SIZE: usize = 1000;
-    let heap_space = Box::leak(Box::new(Chonk::<HEAP_SIZE>::new()));
-    let data = &mut heap_space.data[ct..];
-    let heap = Heap::from_slice(data);
-    heap
 }
 
 #[test]


### PR DESCRIPTION
If the resulting back padding is too small to be stored as a hole, we treat the hole as unsuitable for the allocation. This way, we avoid unrecoverable leaks of that back padding, which can add up over time and fragment the heap.

Fixes #66 