### PR TITLE
Run new cargo-fuzz job on CI with time limit

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,42 @@
+name: Fuzz
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "*"
+  schedule:
+    - cron: "40 6 * * *" # every day at 6:40
+  pull_request:
+
+env:
+  # disable incremental compilation.
+  #
+  # incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. however,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # see https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). this should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+jobs:
+  fuzz:
+    name: "Fuzzer"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v1
+      - run: cargo install cargo-fuzz
+      - run: cargo fuzz run chaos -- -max_total_time=300


### PR DESCRIPTION
Runs the new chaos fuzzer added in https://github.com/rust-osdev/linked-list-allocator/pull/69 as a CI job.