### PR TITLE
detect fragmentation when fuzzing

### DIFF
--- a/fuzz/fuzz_targets/chaos.rs
+++ b/fuzz/fuzz_targets/chaos.rs
@@ -117,4 +117,8 @@ fn fuzz(size: u16, actions: Vec<Action>) {
             heap.deallocate(ptr, layout);
         }
     }
+
+    // make sure we can allocate the full heap (no fragmentation)
+    let full = Layout::from_size_align(heap.size(), 1).unwrap();
+    assert!(heap.allocate_first_fit(full).is_ok());
 }


### PR DESCRIPTION
after a single fuzz run, we already free all allocations, so this adds an assertion that we can indeed allocate the full span of the Heap.

This should be a good regression test, as it does catch the fragmentation issue #66 when on the affected version. (and the current impl passes!)