### PR TITLE
Address unleaking of heap data causing miri test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     name: "Miri tests"
     runs-on: ubuntu-latest
     env:
-      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers -Zmiri-ignore-leaks"
+      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers"
     steps:
     - uses: actions/checkout@v1
     - run: rustup toolchain install nightly --profile minimal --component rust-src miri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     name: "Miri tests"
     runs-on: ubuntu-latest
     env:
-      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers"
+      MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers -Zmiri-ignore-leaks"
     steps:
     - uses: actions/checkout@v1
     - run: rustup toolchain install nightly --profile minimal --component rust-src miri

--- a/src/test.rs
+++ b/src/test.rs
@@ -53,6 +53,9 @@ impl<const N: usize> Drop for Dropper<N> {
 
 pub struct OwnedHeap<const N: usize> {
     heap: Heap,
+    // /!\ SAFETY /!\: Load bearing drop order! `_drop` MUST be dropped AFTER
+    // `heap` is dropped. This is enforced by rust's built-in drop ordering, as
+    // long as `_drop` is declared after `heap`.
     _drop: Dropper<N>,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,15 +43,14 @@ impl<F> DerefMut for OwnedHeap<F> {
 pub fn new_heap() -> OwnedHeap<impl Sized> {
     const HEAP_SIZE: usize = 1000;
     let mut heap_space = Box::new(Chonk::<HEAP_SIZE>::new());
-    let data = &mut heap_space.data;
+    let data = &mut Box::leak(heap_space).data;
     let assumed_location = data.as_mut_ptr().cast();
 
     let heap = unsafe { Heap::new(data.as_mut_ptr().cast(), data.len()) };
     assert_eq!(heap.bottom(), assumed_location);
     assert_eq!(heap.size(), align_down_size(HEAP_SIZE, size_of::<usize>()));
-
     let drop = move || {
-        let _ = heap_space;
+        // let _ = heap_space;
     };
     OwnedHeap { heap, _drop: drop }
 }
@@ -60,7 +59,7 @@ fn new_max_heap() -> OwnedHeap<impl Sized> {
     const HEAP_SIZE: usize = 1024;
     const HEAP_SIZE_MAX: usize = 2048;
     let mut heap_space = Box::new(Chonk::<HEAP_SIZE_MAX>::new());
-    let data = &mut heap_space.data;
+    let data = &mut Box::leak(heap_space).data;
     let start_ptr = data.as_mut_ptr().cast();
 
     // Unsafe so that we have provenance over the whole allocation.
@@ -69,7 +68,7 @@ fn new_max_heap() -> OwnedHeap<impl Sized> {
     assert_eq!(heap.size(), HEAP_SIZE);
 
     let drop = move || {
-        let _ = heap_space;
+        // let _ = heap_space;
     };
     OwnedHeap { heap, _drop: drop }
 }
@@ -77,11 +76,11 @@ fn new_max_heap() -> OwnedHeap<impl Sized> {
 fn new_heap_skip(ct: usize) -> OwnedHeap<impl Sized> {
     const HEAP_SIZE: usize = 1000;
     let mut heap_space = Box::new(Chonk::<HEAP_SIZE>::new());
-    let data = &mut heap_space.data[ct..];
+    let data = &mut Box::leak(heap_space).data[ct..];
     let heap = unsafe { Heap::new(data.as_mut_ptr().cast(), data.len()) };
 
     let drop = move || {
-        let _ = heap_space;
+        // let _ = heap_space;
     };
     OwnedHeap { heap, _drop: drop }
 }


### PR DESCRIPTION
Fixes #74

It seems that the changes made to tests in https://github.com/rust-osdev/linked-list-allocator/pull/71 to unleak the heap buffers and allow disabling `-Zmiri-ignore-leaks` did so in a way that now makes miri angery.

This is currently a minimal commit disabling the leak step (in a hacky way). I'm going to investigate if there is a sound way to do this.