### PR TITLE
Remove features const_mut_refs and use_spin_nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ repository = "https://github.com/phil-opp/linked-list-allocator"
 documentation = "https://docs.rs/crate/linked_list_allocator"
 homepage = "http://os.phil-opp.com/kernel-heap.html#a-better-allocator"
 
+rust-version = "1.61"
+
 [features]
-default = ["use_spin_nightly"]
-use_spin = ["spinning_top"]
-use_spin_nightly = ["use_spin", "spinning_top/nightly", "const_mut_refs"]
+default = ["use_spin"]
+use_spin = ["spinning_top", "dep:lock_api"]
+# deprecated - use `use_spin` instead
+use_spin_nightly = ["use_spin"]
 alloc_ref = []
+# deprecated - no effect
 const_mut_refs = []
 
 [dependencies.spinning_top]
@@ -28,3 +32,10 @@ pre-release-replacements = [
     { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
 ]
 pre-release-commit-message = "Release version {{version}}"
+
+# This is only used indirectly, via spinning_top. It's declared here as well
+# to guarantee the use of a version >= 0.4.7. Once spinning_top depends
+# on a sufficiently recent version, this dependency can be removed.
+[dependencies.lock_api]
+version = "0.4.7"
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.61"
 
 [features]
 default = ["use_spin"]
-use_spin = ["spinning_top", "dep:lock_api"]
+use_spin = ["spinning_top"]
 # deprecated - use `use_spin` instead
 use_spin_nightly = ["use_spin"]
 alloc_ref = []
@@ -23,7 +23,7 @@ alloc_ref = []
 const_mut_refs = []
 
 [dependencies.spinning_top]
-version = "0.2.3"
+version = "0.2.5"
 optional = true
 
 [package.metadata.release]
@@ -32,10 +32,3 @@ pre-release-replacements = [
     { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
 ]
 pre-release-commit-message = "Release version {{version}}"
-
-# This is only used indirectly, via spinning_top. It's declared here as well
-# to guarantee the use of a version >= 0.4.7. Once spinning_top depends
-# on a sufficiently recent version, this dependency can be removed.
-[dependencies.lock_api]
-version = "0.4.7"
-optional = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- Remove features const_mut_refs and use_spin_nightly. Since rust 1.61, the underlying const functions are available in stable rust,
+  and lock_api >= 0.4.7 automatically uses them. (Feature const_fn_trait_bound, https://github.com/rust-lang/rust/pull/93827)
+  To avoid a breaking change, the features are still listed in Cargo.toml, but have no effect and are marked as deprecated.
+  This bumps the minimum supported rust version to 1.61.
+
 # 0.10.4 – 2022-10-10
 
 - Fix [memory leak of small back paddings](https://github.com/rust-osdev/linked-list-allocator/issues/66) by considering regions that would result in such small back paddings as unsuitable ([#71](https://github.com/rust-osdev/linked-list-allocator/pull/71))

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ pub fn init_heap() {
 ## Features
 
 - **`use_spin`** (default): Provide a `LockedHeap` type that implements the [`GlobalAlloc`] trait by using a spinlock.
-- **`const_mut_refs`** (default): Makes the `Heap::empty` function `const`; requires nightly Rust.
-- **`use_spin_nightly`** (default): Makes the `LockedHeap::empty` function `const`, automatically enables `use_spin` and `const_mut_refs`; requires nightly Rust.
 - **`alloc_ref`**: Provide an implementation of the unstable [`AllocRef`] trait; requires nightly Rust.
     - Warning: The `AllocRef` trait is still regularly changed on the Rust side, so expect some regular breakage when using this feature.
 

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -257,21 +257,6 @@ fn check_merge_bottom(node: NonNull<Hole>, bottom: *mut u8) -> NonNull<Hole> {
 
 impl HoleList {
     /// Creates an empty `HoleList`.
-    #[cfg(not(feature = "const_mut_refs"))]
-    pub fn empty() -> HoleList {
-        HoleList {
-            first: Hole {
-                size: 0,
-                next: None,
-            },
-            bottom: null_mut(),
-            top: null_mut(),
-            pending_extend: 0,
-        }
-    }
-
-    /// Creates an empty `HoleList`.
-    #[cfg(feature = "const_mut_refs")]
     pub const fn empty() -> HoleList {
         HoleList {
             first: Hole {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "const_mut_refs", feature(const_mut_refs))]
 #![cfg_attr(
     feature = "alloc_ref",
     feature(allocator_api, alloc_layout_extra, nonnull_slice_from_raw_parts)
@@ -55,15 +54,6 @@ unsafe impl Send for Heap {}
 
 impl Heap {
     /// Creates an empty heap. All allocate calls will return `None`.
-    #[cfg(not(feature = "const_mut_refs"))]
-    pub fn empty() -> Heap {
-        Heap {
-            used: 0,
-            holes: HoleList::empty(),
-        }
-    }
-
-    #[cfg(feature = "const_mut_refs")]
     pub const fn empty() -> Heap {
         Heap {
             used: 0,
@@ -300,15 +290,7 @@ pub struct LockedHeap(Spinlock<Heap>);
 
 #[cfg(feature = "use_spin")]
 impl LockedHeap {
-    /// Creates an empty heap. All allocate calls will return `None`.
-    #[cfg(feature = "use_spin_nightly")]
     pub const fn empty() -> LockedHeap {
-        LockedHeap(Spinlock::new(Heap::empty()))
-    }
-
-    /// Creates an empty heap. All allocate calls will return `None`.
-    #[cfg(not(feature = "use_spin_nightly"))]
-    pub fn empty() -> LockedHeap {
         LockedHeap(Spinlock::new(Heap::empty()))
     }
 


### PR DESCRIPTION
Since rust 1.61, the underlying const functions are available in stable rust, and lock_api >= 0.4.7 automatically uses them. (Feature const_fn_trait_bound, https://github.com/rust-lang/rust/pull/93827)

To avoid a breaking change, the features are still listed in Cargo.toml, but have no effect and are marked as deprecated.  This bumps the minimum supported rust version to 1.61.