### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["allocator", "no_std", "malloc", "heap", "kernel"]
 
 repository = "https://github.com/phil-opp/linked-list-allocator"
 documentation = "https://docs.rs/crate/linked_list_allocator"
-homepage = "http://os.phil-opp.com/kernel-heap.html#a-better-allocator"
+homepage = "https://os.phil-opp.com/kernel-heap.html#a-better-allocator"
 
 rust-version = "1.61"
 


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://os.phil-opp.com/kernel-heap.html#a-better-allocator` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

