### PR TITLE
Fix warnings about `cfg(fuzzing)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ const_mut_refs = []
 version = "0.2.5"
 optional = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [package.metadata.release]
 dev-version = false
 pre-release-replacements = [


### PR DESCRIPTION
Rust now warns about unexpected `cfg` conditions.
